### PR TITLE
Fix import error

### DIFF
--- a/flask_gcp_log_groups/__init__.py
+++ b/flask_gcp_log_groups/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from .gcp_logging import GCPHandler
+from flask_gcp_log_groups.gcp_logging import GCPHandler

--- a/flask_gcp_log_groups/__init__.py
+++ b/flask_gcp_log_groups/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from gcp_logging import GCPHandler
+from .gcp_logging import GCPHandler

--- a/flask_gcp_log_groups/gcp_logging.py
+++ b/flask_gcp_log_groups/gcp_logging.py
@@ -41,7 +41,7 @@ class GCPHandler(logging.Handler):
         self.mLogLevels.append(SEVERITY)
         TRACE = None
         SPAN = None
-        if (self.traceHeaderName):
+        if request.headers.get(self.traceHeaderName):
           # trace can be formatted as "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
           rawTrace = request.headers.get(self.traceHeaderName).split('/')
           TRACE = rawTrace[0]

--- a/flask_gcp_log_groups/gcp_logging.py
+++ b/flask_gcp_log_groups/gcp_logging.py
@@ -11,7 +11,7 @@ from flask import Flask
 from flask import request, Response, render_template, g, jsonify, current_app
 
 from google.cloud import logging as gcplogging
-from .background_thread import BackgroundThreadTransport
+from flask_gcp_log_groups.background_thread import BackgroundThreadTransport
 
 logger = logging.getLogger(__name__)
 client = gcplogging.Client()
@@ -41,7 +41,7 @@ class GCPHandler(logging.Handler):
         self.mLogLevels.append(SEVERITY)
         TRACE = None
         SPAN = None
-        if request.headers.get(self.traceHeaderName):
+        if (self.traceHeaderName in request.headers.keys()):
           # trace can be formatted as "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
           rawTrace = request.headers.get(self.traceHeaderName).split('/')
           TRACE = rawTrace[0]
@@ -70,7 +70,7 @@ class GCPHandler(logging.Handler):
         def add_logger(response):
             TRACE = None
             SPAN = None
-            if (self.traceHeaderName):
+            if (self.traceHeaderName in request.headers.keys()):
               # trace can be formatted as "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
               rawTrace = request.headers.get(self.traceHeaderName).split('/')
               TRACE = rawTrace[0]

--- a/flask_gcp_log_groups/gcp_logging.py
+++ b/flask_gcp_log_groups/gcp_logging.py
@@ -11,7 +11,7 @@ from flask import Flask
 from flask import request, Response, render_template, g, jsonify, current_app
 
 from google.cloud import logging as gcplogging
-from background_thread import BackgroundThreadTransport
+from .background_thread import BackgroundThreadTransport
 
 logger = logging.getLogger(__name__)
 client = gcplogging.Client()


### PR DESCRIPTION
When I imported module installed by pip, I got 2 errors.

### Cannot import module

```
Attaching to api
api     | Traceback (most recent call last):
api     |   File "main.py", line 15, in <module>
api     |     from flask_gcp_log_groups import GCPHandler
api     | ModuleNotFoundError: No module named 'flask_gcp_log_groups'
```

### Raise error when local environment that has no `X-Cloud-Trace-Context` header.
```
api     | Traceback (most recent call last):
api     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2309, in __call__
api     |     return self.wsgi_app(environ, start_response)
api     |   File "/app/lib/middlewares.py", line 25, in __call__
api     |     return self.app(environ, start_response)
api     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2295, in wsgi_app
api     |     response = self.handle_exception(e)
api     |   File "/usr/local/lib/python3.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
api     |     return cors_after_request(app.make_response(f(*args, **kwargs)))
api     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1741, in handle_exception
api     |     reraise(exc_type, exc_value, tb)
api     |   File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 35, in reraise
api     |     raise value
api     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2292, in wsgi_app
api     |     response = self.full_dispatch_request()
api     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1816, in full_dispatch_request
api     |     return self.finalize_request(rv)
api     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1833, in finalize_request
api     |     response = self.process_response(response)
api     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2112, in process_response
api     |     response = handler(response)
api     |   File "/usr/local/lib/python3.7/site-packages/flask_gcp_log_groups/gcp_logging.py", line 75, in add_logger
api     |     rawTrace = request.headers.get(self.traceHeaderName).split('/')
api     | AttributeError: 'NoneType' object has no attribute 'split'
```