### PR TITLE
Fixes py3 print and log-level comparison

### DIFF
--- a/flask_gcp_log_groups/gcp_logging.py
+++ b/flask_gcp_log_groups/gcp_logging.py
@@ -32,7 +32,7 @@ class GCPHandler(logging.Handler):
             resource = _GLOBAL_RESOURCE
         else:
             resource = Resource(type=resource['type'], labels=resource['labels'])
-            print str( resource)
+            print(resource)
         self.resource = resource
         self.transport_parent = BackgroundThreadTransport(client, parentLogName)
         self.transport_child = BackgroundThreadTransport(client, childLogName)           
@@ -45,7 +45,7 @@ class GCPHandler(logging.Handler):
         SEVERITY = record.levelname
 
         # if the current log is at a lower level than is setup, skip it
-        if (record.levelname <= logging.getLevelName):
+        if (record.levelno <= logger.level):
             return
         self.mLogLevels.append(SEVERITY)
         TRACE = None


### PR DESCRIPTION
Two fixes:
- py3-ify a print statement
- fixes an incorrect numeric comparison of the log level name instead of numbers.